### PR TITLE
Docs/simplify link

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -1,4 +1,4 @@
-Other things that do not fit a category
+Miscellaneous
 ---
 
-1. [Glossary](https://github.com/prismlab/docs/blob/master/misc/glossary.md)
+* [Glossary](https://github.com/prismlab/docs/blob/master/misc/glossary.md)

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,4 +1,4 @@
 Other things that do not fit a category
 ---
 
-1. [Link](https://github.com/prismlab/docs/blob/master/misc/glossary.md) - Glossary
+1. [Glossary](https://github.com/prismlab/docs/blob/master/misc/glossary.md)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -7,5 +7,5 @@ dealing with OCaml system and other cases.
 Current Tutorials
 ===
 
-1. [Link](https://github.com/prismlab/docs/blob/master/tutorials/setting-up-development-compiler.md) - Setting up a development OCaml compiler with OPAM
-2. [Link](https://github.com/prismlab/docs/blob/master/tutorials/adding-benchmark-to-sandmark.md) - Adding a benchmark to Sandmark
+1. [Setting up a development OCaml compiler with OPAM](https://github.com/prismlab/docs/blob/master/tutorials/setting-up-development-compiler.md)
+2. [Adding a benchmark to Sandmark](https://github.com/prismlab/docs/blob/master/tutorials/adding-benchmark-to-sandmark.md)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -7,5 +7,5 @@ dealing with OCaml system and other cases.
 Current Tutorials
 ===
 
-1. [Setting up a development OCaml compiler with OPAM](https://github.com/prismlab/docs/blob/master/tutorials/setting-up-development-compiler.md)
-2. [Adding a benchmark to Sandmark](https://github.com/prismlab/docs/blob/master/tutorials/adding-benchmark-to-sandmark.md)
+* [Adding a benchmark to Sandmark](https://github.com/prismlab/docs/blob/master/tutorials/adding-benchmark-to-sandmark.md)
+* [Setting up a development OCaml compiler with OPAM](https://github.com/prismlab/docs/blob/master/tutorials/setting-up-development-compiler.md)


### PR DESCRIPTION
* Use "*" for listing entries, as manually inserting numbers can become tedious as the list grows.
* Use alphabetical ordering when listing entries (updated tutorials/README.md).
* Simplify "\[Link\]\(URL\) - Title" with "\[Title\]\(URL\)".