### PR TITLE
Docs/add more acronyms

### DIFF
--- a/misc/glossary.md
+++ b/misc/glossary.md
@@ -4,9 +4,9 @@ Note: Use alphabetical order.
 
 Acronym | Expansion
 ------- | ---------
-CAML    | Categorical Abstract Machine Language
+Caml    | Categorical Abstract Machine Language
 KR      | Key Results
-OCAML   | Objective CAML
+OCaml   | Objective Caml
 OKR     | Objective Key Results
 OPAM    | OCaml Package Manager
 RR      | Record and Replay Framework

--- a/misc/glossary.md
+++ b/misc/glossary.md
@@ -5,8 +5,18 @@ Note: Use alphabetical order.
 Acronym | Expansion
 ------- | ---------
 Caml    | Categorical Abstract Machine Language
+CRCW    | Concurrent Read, Concurrent Write
+CREW    | Concurrent Read, Exclusive Write
+ERCW    | Exclusive Read, Concurrent Write
+EREW    | Exclusive Read, Exclusive Write
 KR      | Key Results
 OCaml   | Objective Caml
 OKR     | Objective Key Results
 OPAM    | OCaml Package Manager
+OpenMP  | Open Multi-Processing
+MPI     | Message Passing Interface
+POSIX   | Portable Operating System Interface
+PRAM    | Parallel Random Access Memory
+PVM     | Parallel Virtual Machine
 RR      | Record and Replay Framework
+TLS     | Thread-Local Storage

--- a/misc/glossary.md
+++ b/misc/glossary.md
@@ -4,5 +4,9 @@ Note: Use alphabetical order.
 
 Acronym | Expansion
 ------- | ---------
+CAML    | Categorical Abstract Machine Language
 KR      | Key Results
+OCAML   | Objective CAML
 OKR     | Objective Key Results
+OPAM    | OCaml Package Manager
+RR      | Record and Replay Framework

--- a/misc/glossary.md
+++ b/misc/glossary.md
@@ -4,19 +4,28 @@ Note: Use alphabetical order.
 
 Acronym | Expansion
 ------- | ---------
+ADT     | Abstract Data Type
 Caml    | Categorical Abstract Machine Language
 CRCW    | Concurrent Read, Concurrent Write
 CREW    | Concurrent Read, Exclusive Write
+CSP     | Communicating Sequential Processes
+        | Constraint Satisfaction Problem
+CTM     | Concepts, Techniques, and Models of Computer Programming (ctm.info.ucl.ac.be)
+DCG     | Definitive Clause Grammar (in Prolog)
 ERCW    | Exclusive Read, Concurrent Write
 EREW    | Exclusive Read, Exclusive Write
+GCL     | Guarded Command Language (by Edsger Dijkstra)
 KR      | Key Results
 OCaml   | Objective Caml
 OKR     | Objective Key Results
 OPAM    | OCaml Package Manager
 OpenMP  | Open Multi-Processing
 MPI     | Message Passing Interface
+OTP     | Open Telecom Platform (from Erlang)
+PDA     | Procedural Data Abstraction
 POSIX   | Portable Operating System Interface
 PRAM    | Parallel Random Access Memory
 PVM     | Parallel Virtual Machine
 RR      | Record and Replay Framework
+SQL     | Structured Query Language
 TLS     | Thread-Local Storage


### PR DESCRIPTION
Added acronym expansions for Caml, OCaml, OPAM and RR. Note the production rule style usage for OCaml :)